### PR TITLE
Labelled Progress bar to 1.0.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 
     ext.tmg_utils = "2.0.1"
     ext.tmg_components = "3.0.0"
-    ext.tmg_labelled_progressbar = "1.0.4"
+    ext.tmg_labelled_progressbar = "1.0.5"
 
     ext.lottie = "3.4.0"
 


### PR DESCRIPTION
- Bumps labelled progress bar version to 1.0.5
- Fixes bug where depending on update cycle the last value isn't shown due to rounding