### PR TITLE
Disables search from remote config for builds

### DIFF
--- a/app-firebase/src/main/java/tmg/flashback/firebase/config/FirebaseRemoteConfigRepository.kt
+++ b/app-firebase/src/main/java/tmg/flashback/firebase/config/FirebaseRemoteConfigRepository.kt
@@ -73,7 +73,7 @@ class FirebaseRemoteConfigRepository(
         }
 
     override val search: Boolean
-        get() = remoteConfig.getBoolean(keySearch)
+        get() = false // remoteConfig.getBoolean(keySearch)
 
     //endregion
 


### PR DESCRIPTION
- Sets search to be false in the remote config evaluator whilst code is not ready