### PR TITLE
Window animations on activity exit

### DIFF
--- a/app/src/main/java/tmg/flashback/ui/base/BaseActivity.kt
+++ b/app/src/main/java/tmg/flashback/ui/base/BaseActivity.kt
@@ -12,6 +12,11 @@ import tmg.utilities.lifecycle.common.CommonActivity
 
 abstract class BaseActivity : CommonActivity() {
 
+    /**
+     * Should we use the translucent variant of the theme or not
+     */
+    open val themeType: ThemeTypes = ThemeTypes.TRANSLUCENT
+
     private val prefsRepository: UserRepository by inject()
 
     protected var isLightTheme: Boolean = true
@@ -44,9 +49,15 @@ abstract class BaseActivity : CommonActivity() {
     @StyleRes
     private fun getThemeStyle(): Int {
         isLightTheme = prefsRepository.theme.isLightMode(this)
+
         return when (isLightTheme) {
-            true -> R.style.LightTheme
-            false -> R.style.DarkTheme
+            true -> themeType.lightTheme
+            false -> themeType.darkTheme
         }
+    }
+
+    override fun finish() {
+        super.finish()
+        overridePendingTransition(R.anim.activity_enter, R.anim.activity_exit)
     }
 }

--- a/app/src/main/java/tmg/flashback/ui/base/ThemeTypes.kt
+++ b/app/src/main/java/tmg/flashback/ui/base/ThemeTypes.kt
@@ -1,0 +1,15 @@
+package tmg.flashback.ui.base
+
+import androidx.annotation.StyleRes
+import tmg.flashback.R
+
+enum class ThemeTypes(
+        @StyleRes
+        val lightTheme: Int,
+        @StyleRes
+        val darkTheme: Int
+) {
+    DEFAULT(lightTheme = R.style.LightTheme, darkTheme = R.style.DarkTheme),
+    TRANSLUCENT(lightTheme = R.style.LightTheme_Translucent, darkTheme = R.style.DarkTheme_Translucent),
+    ABOUT_APP(lightTheme = R.style.LightTheme_AboutThisApp, darkTheme = R.style.DarkTheme_AboutThisApp)
+}

--- a/app/src/main/java/tmg/flashback/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/tmg/flashback/ui/dashboard/DashboardActivity.kt
@@ -2,6 +2,8 @@ package tmg.flashback.ui.dashboard
 
 import android.content.Intent
 import android.os.Bundle
+import android.transition.Transition
+import androidx.annotation.StyleRes
 import com.discord.panels.OverlappingPanelsLayout
 import com.discord.panels.OverlappingPanelsLayout.Panel.CENTER
 import com.discord.panels.OverlappingPanelsLayout.Panel.END
@@ -9,11 +11,13 @@ import kotlinx.android.synthetic.main.activity_dashboard.*
 import org.koin.android.ext.android.inject
 import org.koin.android.viewmodel.ext.android.viewModel
 import tmg.flashback.R
+import tmg.flashback.extensions.isLightMode
 import tmg.flashback.ui.base.BaseActivity
 import tmg.flashback.ui.dashboard.list.ListFragment
 import tmg.flashback.ui.dashboard.search.SearchFragment
 import tmg.flashback.ui.dashboard.season.SeasonFragment
 import tmg.flashback.repo.config.RemoteConfigRepository
+import tmg.flashback.ui.base.ThemeTypes
 import tmg.flashback.ui.settings.release.ReleaseBottomSheetFragment
 import tmg.utilities.extensions.loadFragment
 import tmg.utilities.extensions.observeEvent
@@ -21,6 +25,7 @@ import tmg.utilities.extensions.observeEvent
 class DashboardActivity: BaseActivity(), DashboardNavigationCallback {
 
     override val initialiseSlidr: Boolean = false
+    override val themeType: ThemeTypes = ThemeTypes.DEFAULT
 
     private val remoteConfigRepository: RemoteConfigRepository by inject()
 

--- a/app/src/main/res/anim/activity_enter.xml
+++ b/app/src/main/res/anim/activity_enter.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromYDelta="100%"
+        android:interpolator="@android:anim/decelerate_interpolator"
+        android:toYDelta="0" />
+</set>

--- a/app/src/main/res/anim/activity_exit.xml
+++ b/app/src/main/res/anim/activity_exit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:fromYDelta="0"
+        android:toYDelta="100%"
+        android:interpolator="@android:anim/accelerate_interpolator"
+        android:duration="@android:integer/config_shortAnimTime"/>
+</set>

--- a/app/src/main/res/values-v27/style-day.xml
+++ b/app/src/main/res/values-v27/style-day.xml
@@ -10,9 +10,6 @@
         <item name="android:windowLightStatusBar">true</item>
         <item name="android:windowLightNavigationBar">true</item>
 
-        <item name="android:windowIsTranslucent">true</item>
-        <item name="android:windowBackground">#00ffffff</item>
-
         <item name="f1BackgroundHighlighted">#334A34B6</item>
 
         <item name="f1TextPrimary">#181818</item>
@@ -59,6 +56,11 @@
         <item name="rssTextPrimary">?attr/f1TextPrimary</item>
         <item name="rssTextSecondary">?attr/f1TextSecondary</item>
         <item name="rssTextTertiary">?attr/f1TextTertiary</item>
+    </style>
+
+    <style name="LightTheme.Translucent" parent="LightTheme">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">#00ffffff</item>
     </style>
 
     <style name="LightTheme.AboutThisApp" parent="LightTheme">

--- a/app/src/main/res/values/style-day.xml
+++ b/app/src/main/res/values/style-day.xml
@@ -8,9 +8,6 @@
         <item name="android:statusBarColor">?attr/f1BackgroundPrimary</item>
         <item name="android:windowLightStatusBar">true</item>
 
-        <item name="android:windowIsTranslucent">true</item>
-        <item name="android:windowBackground">#00ffffff</item>
-
         <item name="f1BackgroundHighlighted">#334A34B6</item>
 
         <item name="f1TextPrimary">#181818</item>
@@ -57,6 +54,11 @@
         <item name="rssTextPrimary">?attr/f1TextPrimary</item>
         <item name="rssTextSecondary">?attr/f1TextSecondary</item>
         <item name="rssTextTertiary">?attr/f1TextTertiary</item>
+    </style>
+
+    <style name="LightTheme.Translucent" parent="LightTheme">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">#00ffffff</item>
     </style>
 
     <style name="LightTheme.AboutThisApp" parent="LightTheme">

--- a/app/src/main/res/values/style-night.xml
+++ b/app/src/main/res/values/style-night.xml
@@ -10,9 +10,6 @@
         <item name="android:windowLightStatusBar">false</item>
         <item name="android:windowLightNavigationBar">false</item>
 
-        <item name="android:windowIsTranslucent">true</item>
-        <item name="android:windowBackground">#00000000</item>
-
         <item name="f1BackgroundHighlighted">#334A34B6</item>
 
         <item name="f1TextPrimary">#F8F8F8</item>
@@ -59,6 +56,11 @@
         <item name="rssTextPrimary">?attr/f1TextPrimary</item>
         <item name="rssTextSecondary">?attr/f1TextSecondary</item>
         <item name="rssTextTertiary">?attr/f1TextTertiary</item>
+    </style>
+
+    <style name="DarkTheme.Translucent" parent="DarkTheme">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">#00000000</item>
     </style>
 
     <style name="DarkTheme.AboutThisApp" parent="DarkTheme">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -11,7 +11,6 @@
         <item name="android:windowBackground">@android:color/transparent</item>
     </style>
 
-
     <!-- =========================================== -->
 
     <!-- =========================================== -->

--- a/rss/src/main/java/tmg/flashback/rss/base/RSSBaseActivity.kt
+++ b/rss/src/main/java/tmg/flashback/rss/base/RSSBaseActivity.kt
@@ -32,7 +32,6 @@ abstract class RSSBaseActivity: CommonActivity() {
 
     //endregion
 
-
     override fun onCreate(savedInstanceState: Bundle?) {
         setTheme(getThemeStyle())
         super.onCreate(savedInstanceState)
@@ -49,5 +48,10 @@ abstract class RSSBaseActivity: CommonActivity() {
             true -> R.style.RSS_LightTheme
             false -> R.style.RSS_DarkTheme
         }
+    }
+
+    override fun finish() {
+        super.finish()
+        overridePendingTransition(R.anim.activity_enter, R.anim.activity_exit)
     }
 }

--- a/rss/src/main/res/anim/activity_enter.xml
+++ b/rss/src/main/res/anim/activity_enter.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="@android:integer/config_mediumAnimTime"
+        android:fromYDelta="100%"
+        android:interpolator="@android:anim/decelerate_interpolator"
+        android:toYDelta="0" />
+</set>

--- a/rss/src/main/res/anim/activity_exit.xml
+++ b/rss/src/main/res/anim/activity_exit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:fromYDelta="0"
+        android:toYDelta="100%"
+        android:interpolator="@android:anim/accelerate_interpolator"
+        android:duration="@android:integer/config_mediumAnimTime"/>
+</set>


### PR DESCRIPTION
- Fixes window activity animation when running on a real device by overriding back transition
- Split out themes into `LightTheme` and `LightTheme.Translucent` with default being translucent to fix this problem for future activities. 
- Fixes dashboard activity theme type to use stock activity transition on back