### PR TITLE
Allow round to be null / 0 in up next

### DIFF
--- a/app-firebase/src/main/java/tmg/flashback/firebase/converters/UpNextConverter.kt
+++ b/app-firebase/src/main/java/tmg/flashback/firebase/converters/UpNextConverter.kt
@@ -17,7 +17,7 @@ fun FUpNext.convert(): List<UpNextSchedule> {
 }
 
 fun FUpNextSchedule.convert(): UpNextSchedule? {
-    if (this.s == null || this.r == null || this.name == null || this.date == null) {
+    if (this.s == null || this.name == null || this.date == null) {
         return null
     }
 
@@ -30,7 +30,7 @@ fun FUpNextSchedule.convert(): UpNextSchedule? {
 
     return UpNextSchedule(
         season = this.s,
-        round = this.r,
+        round = this.r ?: 0,
         name = this.name,
         date = date,
         time = fromTime(this.time),

--- a/app/src/main/java/tmg/flashback/ui/dashboard/list/viewholders/UpNextViewHolder.kt
+++ b/app/src/main/java/tmg/flashback/ui/dashboard/list/viewholders/UpNextViewHolder.kt
@@ -18,6 +18,7 @@ import kotlin.math.absoluteValue
 
 class UpNextViewHolder(itemView: View): RecyclerView.ViewHolder(itemView) {
 
+    @SuppressLint("SetTextI18n")
     fun bind(item: ListItem.UpNext) {
 
         itemView.name.text = item.upNextSchedule.name
@@ -50,7 +51,12 @@ class UpNextViewHolder(itemView: View): RecyclerView.ViewHolder(itemView) {
         // Days to go
         @SuppressLint("SetTextI18n")
         val dateString = "${item.upNextSchedule.date.dayOfMonth.ordinalAbbreviation} ${DateTimeFormatter.ofPattern("MMM yyyy").format(item.upNextSchedule.date)}"
-        itemView.date.text = getString(R.string.dashboard_up_next_date, item.upNextSchedule.round, dateString).fromHtml()
+        if (item.upNextSchedule.round != 0) {
+            itemView.date.text = getString(R.string.dashboard_up_next_date, item.upNextSchedule.round, dateString).fromHtml()
+        }
+        else {
+            itemView.date.text = "<br/><b>${dateString}</b>".fromHtml()
+        }
         if (item.upNextSchedule.date == LocalDate.now()) {
             itemView.days.text = getString(R.string.dashboard_up_next_today)
             itemView.daysToGoLabel.gone()


### PR DESCRIPTION
- Allows `r` field (round) supplied by remote config to be null and not shown in the "Up next" category to allow generic message to be displayed