### PR TITLE
Calendar weekday view

### DIFF
--- a/feature/statistics/src/main/java/tmg/flashback/statistics/ui/dashboard/season/viewholders/CalendarWeekViewHolder.kt
+++ b/feature/statistics/src/main/java/tmg/flashback/statistics/ui/dashboard/season/viewholders/CalendarWeekViewHolder.kt
@@ -47,6 +47,7 @@ class CalendarWeekViewHolder(
 
         cells.forEach {
             it.day.text = ""
+            it.day.setBackgroundResource(0)
         }
 
         val startingIndex = item.startingDay.dayOfWeek.value - 1


### PR DESCRIPTION
- Fixes bug with week view in the calendar where view recycling means that the indicator for the current day is sometimes set to a cell which doesn't have text when scrolling.