### PR TITLE
Gradle play publisher to 3.5.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,11 @@ buildscript {
         maven {
             url 'https://maven.fabric.io/public'
         }
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
-        classpath "com.github.triplet.gradle:play-publisher:3.4.0"
+        classpath "com.github.triplet.gradle:play-publisher:3.5.0-SNAPSHOT"
         classpath 'com.google.gms:google-services:4.3.5'
         classpath "org.koin:koin-gradle-plugin:$koin_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"


### PR DESCRIPTION
- Updates the gradle play publisher version to use the snapshot 3.5.0-SNAPSHOT version