### PR TITLE
BAU: Dependency update

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -31,5 +31,10 @@
       <option name="name" value="maven" />
       <option name="url" value="https://oss.sonatype.org/content/repositories/snapshots" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
   </component>
 </project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -336,19 +336,13 @@ dependencies {
     androidTestImplementation "org.junit.jupiter:junit-jupiter-params:$junit"
     androidTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit"
     androidTestImplementation "io.mockk:mockk-android:$mockk"
-    androidTestImplementation "org.koin:koin-test:$koin_version"
+    androidTestImplementation "io.insert-koin:koin-test:$koin_version"
     androidTestImplementation('com.schibsted.spain:barista:3.7.0') {
         exclude group: 'org.jetbrains.kotlin' // Only if you already use Kotlin in your project
     }
 
     // Discord Overlapping panels
     implementation 'com.github.discord:OverlappingPanels:0.1.1'
-
-    // Progress bar
-    implementation 'com.aswin:CustomArc:1.0.2'
-
-    // Fast indicator
-    implementation 'com.reddit:indicator-fast-scroll:1.3.0'
 
     // TMG dependencies
     implementation "com.github.thementalgoose:android-about-this-app:$tmg_about_this_app"
@@ -363,10 +357,7 @@ dependencies {
     kapt "com.github.bumptech.glide:compiler:$glide"
 
     // BugShaker
-    implementation 'com.github.stkent:bugshaker:1.4.1'
-
-    // Indicator scroller
-    implementation 'com.reddit:indicator-fast-scroll:1.3.0'
+    implementation 'com.github.stkent:bugshaker:2.0.0'
 
     // Lottie
     implementation "com.airbnb.android:lottie:$lottie"

--- a/base-dependencies.gradle
+++ b/base-dependencies.gradle
@@ -40,10 +40,10 @@ dependencies {
     implementation "androidx.preference:preference-ktx:1.1.1"
 
     // Koin
-    implementation "org.koin:koin-android:$koin_version"
-    implementation "org.koin:koin-android-scope:$koin_version"
-    implementation "org.koin:koin-android-viewmodel:$koin_version"
-    implementation "org.koin:koin-android-ext:$koin_version"
+    implementation "io.insert-koin:koin-android:$koin_version"
+    implementation "io.insert-koin:koin-android-scope:$koin_version"
+    implementation "io.insert-koin:koin-android-viewmodel:$koin_version"
+    implementation "io.insert-koin:koin-android-ext:$koin_version"
 
     // ThreeTen
     implementation "com.jakewharton.threetenabp:threetenabp:$threeten"

--- a/base-versions.gradle
+++ b/base-versions.gradle
@@ -1,14 +1,14 @@
 ext {
-    kotlin_version = "1.5.0"
+    kotlin_version = "1.5.10"
     koin_version = "2.2.2"
-    coroutines = "1.4.1"
+    coroutines = "1.5.0"
     navigation = "2.3.5"
 
     mockk = "1.10.3-jdk8"
     junit = "5.5.2"
 
-    threeten = "1.2.2"
-    threetenbp = "1.4.1"
+    threeten = "1.3.1"
+    threetenbp = "1.5.1"
 
     android_constraint = "2.0.4"
     android_material = "1.3.0"

--- a/build.gradle
+++ b/build.gradle
@@ -11,16 +11,18 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
         mavenCentral()
         maven {
             url 'https://maven.fabric.io/public'
+        }
+        maven {
+            url "https://plugins.gradle.org/m2/"
         }
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
-        classpath "com.github.triplet.gradle:play-publisher:3.5.0-SNAPSHOT"
+        classpath "com.github.triplet.gradle:play-publisher:3.4.0-agp4.2"
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.koin:koin-gradle-plugin:$koin_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -34,7 +36,22 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        jcenter() {
+            content {
+                // https://github.com/Faltenreich/SkeletonLayout/issues/29
+                includeModule("com.faltenreich", "skeletonlayout")
+
+                // https://github.com/wangjiejacques/flagkit
+                includeModule("com.jwang123.flagkit", "flagkit")
+
+                // https://github.com/AdevintaSpain/Barista/issues/382
+                includeModule("com.schibsted.spain", "barista")
+
+                // Marked read only by owner, not around forever
+                includeModule("com.github.stkent", "bugshaker")
+            }
+        }
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
         maven { url 'https://jitpack.io' }
     }

--- a/core/base.gradle
+++ b/core/base.gradle
@@ -77,10 +77,10 @@ android {
 dependencies {
 
     // Koin
-    implementation "org.koin:koin-android:$koin_version"
-    implementation "org.koin:koin-android-scope:$koin_version"
-    implementation "org.koin:koin-android-viewmodel:$koin_version"
-    implementation "org.koin:koin-android-ext:$koin_version"
+    implementation "io.insert-koin:koin-android:$koin_version"
+    implementation "io.insert-koin:koin-android-scope:$koin_version"
+    implementation "io.insert-koin:koin-android-viewmodel:$koin_version"
+    implementation "io.insert-koin:koin-android-ext:$koin_version"
 
     // ThreeTen
     implementation "com.jakewharton.threetenabp:threetenabp:$threeten"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip


### PR DESCRIPTION
- Removes jcenter and forces new library usage for most libraries
- Updates koin references from `org.koin` to `io.insert-koin`
- Updates threeten to 1.3.1
- Updates bugshaker to 2.0.0
- Updates android gradle plugin to 7.1
- Updates kotlin version to 1.5.10
- Downgrades play publisher to 3.4.0-agp4.2 