### PR TITLE
Adds more keys for FirebaseCrashService

### DIFF
--- a/core/crash-reporting/src/main/java/tmg/flashback/crash_reporting/services/FirebaseCrashService.kt
+++ b/core/crash-reporting/src/main/java/tmg/flashback/crash_reporting/services/FirebaseCrashService.kt
@@ -16,6 +16,10 @@ internal class FirebaseCrashService: CrashService {
     private val keyDeviceUuid: String = "uuid"
     private val keyModel: String = "model"
     private val keyManufacturer: String = "manufacturer"
+    private val keyFingerprint: String = "fingerprint"
+    private val keyBrand: String = "brand"
+    private val keyBoard: String = "board"
+    private val keyHardware: String = "hardware"
     private val keyProduct: String = "product"
     private val keyDevice: String = "device"
     private val keyAppFirstOpen: String = "appFirstOpen"
@@ -31,10 +35,10 @@ internal class FirebaseCrashService: CrashService {
 
         instance.setCrashlyticsCollectionEnabled(enableCrashReporting)
         if (enableCrashReporting) {
-            Log.i("Flashback", "Enabling crashlytics")
+            Log.i("Crashlytics", "Enabling crashlytics")
         }
         else {
-            Log.i("Flashback", "Disabling crashlytics")
+            Log.i("Crashlytics", "Disabling crashlytics")
         }
 
         instance.setCustomKey(keyEmulator, isEmulator)
@@ -42,10 +46,26 @@ internal class FirebaseCrashService: CrashService {
 
         instance.setUserId(deviceUdid)
         instance.setCustomKey(keyDeviceUuid, deviceUdid)
+        instance.setCustomKey(keyBrand, Build.BRAND)
+        instance.setCustomKey(keyHardware, Build.HARDWARE)
+        instance.setCustomKey(keyBoard, Build.BOARD)
+        instance.setCustomKey(keyFingerprint, Build.FINGERPRINT)
         instance.setCustomKey(keyModel, Build.MODEL)
         instance.setCustomKey(keyManufacturer, Build.MANUFACTURER)
         instance.setCustomKey(keyProduct, Build.PRODUCT)
         instance.setCustomKey(keyDevice, Build.DEVICE)
+
+        if (BuildConfig.DEBUG) {
+            Log.i("Crashlytics", "$keyDeviceUuid -> $deviceUdid")
+            Log.i("Crashlytics", "$keyBrand -> ${Build.BRAND}")
+            Log.i("Crashlytics", "$keyHardware -> ${Build.HARDWARE}")
+            Log.i("Crashlytics", "$keyBoard -> ${Build.BOARD}")
+            Log.i("Crashlytics", "$keyFingerprint -> ${Build.FINGERPRINT}")
+            Log.i("Crashlytics", "$keyModel -> ${Build.MODEL}")
+            Log.i("Crashlytics", "$keyManufacturer -> ${Build.MANUFACTURER}")
+            Log.i("Crashlytics", "$keyProduct -> ${Build.PRODUCT}")
+            Log.i("Crashlytics", "$keyDevice -> ${Build.DEVICE}")
+        }
 
         appFirstOpened.let {
             instance.setCustomKey(keyAppFirstOpen, it)


### PR DESCRIPTION
Adds `brand`, `hardware`, `board` and `fingerprint` to the crashlytics keys