### PR TITLE
Bumps library versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,18 +2,18 @@
 kotlin = "1.9.10"
 ksp = "1.9.10-1.0.13" # Update with kotlin https://github.com/google/ksp/releases
 hilt = "2.48"
-androidx_activity = "1.7.2"
-androidx_navigation = "2.7.3"
+androidx_activity = "1.8.0"
+androidx_navigation = "2.7.4"
 androidx_lifecycle = "2.6.2"
-androidx_hilt = "1.1.0-alpha01"
-androidx_room = "2.6.0-rc01"
+androidx_hilt = "1.1.0-rc01"
+androidx_room = "2.6.0"
 androidx_workmanager = "2.8.1"
 androidx_glance = "1.0.0-alpha03" #beta01 has update frequency issues!
-compose = "2023.09.02"
+compose = "2023.10.01"
 composecompiler = "1.5.3"
 compose_accompanist = "0.30.1"
 coroutines = "1.7.2"
-firebase = "32.3.1"
+firebase = "32.4.0"
 junit = "5.9.3"
 okhttp = "4.11.0"
 retrofit = "2.9.0"
@@ -21,7 +21,7 @@ newrelic = "7.0.0"
 
 [libraries]  # ===========================================================================
 ## Root build.gradle dependencies
-gradle_agp = "com.android.tools.build:gradle:8.1.1"
+gradle_agp = "com.android.tools.build:gradle:8.1.2"
 gradle_crashlytics = "com.google.firebase:firebase-crashlytics-gradle:2.9.9"
 gradle_dep_report = "com.github.ben-manes:gradle-versions-plugin:0.46.0"
 gradle_hilt = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
@@ -54,7 +54,7 @@ androidx_glance_appwidget = { module = "androidx.glance:glance-appwidget", versi
 androidx_workmanager_runtime = { module = "androidx.work:work-runtime", version.ref = "androidx_workmanager" }
 androidx_workmanager_ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "androidx_workmanager" }
 
-material = "com.google.android.material:material:1.9.0"
+material = "com.google.android.material:material:1.10.0"
 
 kotlin_stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin_reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }


### PR DESCRIPTION
- Bumps androidx.activity to 1.8.0
- Bumps androidx.navigation to 2.7.4
- Bumps hilt to 1.1.0-rc01
- Bumps room to 2.6.0
- Bumps compose to 2023.10.01
- Bumps firebase BoM to 32.4.0
- Bumps agp to 8.1.2
- Bumps material to 1.10.0 