### PR TITLE
Bumps some libraries

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]  # ===========================================================================
 kotlin = "1.9.10"
 ksp = "1.9.10-1.0.13" # Update with kotlin https://github.com/google/ksp/releases
-hilt = "2.48"
+hilt = "2.48.1"
 androidx_activity = "1.8.0"
-androidx_navigation = "2.7.4"
+androidx_navigation = "2.7.5"
 androidx_lifecycle = "2.6.2"
-androidx_hilt = "1.1.0-rc01"
+androidx_hilt = "1.1.0"
 androidx_room = "2.6.0"
 androidx_workmanager = "2.8.1"
 androidx_glance = "1.0.0-alpha03" #beta01 has update frequency issues!
@@ -13,7 +13,7 @@ compose = "2023.10.01"
 composecompiler = "1.5.3"
 compose_accompanist = "0.30.1"
 coroutines = "1.7.2"
-firebase = "32.4.0"
+firebase = "32.5.0"
 junit = "5.9.3"
 okhttp = "4.11.0"
 retrofit = "2.9.0"
@@ -123,7 +123,7 @@ room_testing = { module = "androidx.room:room-testing", version.ref = "androidx_
 shakey = "com.linkedin.shaky:shaky:3.0.4"
 falcon = "com.jraska:falcon:2.2.0"
 
-playservicesads = "com.google.android.gms:play-services-ads:22.4.0"
+playservicesads = "com.google.android.gms:play-services-ads:22.5.0"
 
 skeletonlayout = "com.faltenreich:skeletonlayout:4.0.0"
 


### PR DESCRIPTION
Bumps dagger hilt to 2.48.1, hilt to 1.1.0 stable
Bumps navigation to 2.7.5
Bumps firebase bom to 32.5.0
Bumps ads to 22.5.0