### PR TITLE
Cleans up Crashlytics naming

### DIFF
--- a/app/src/main/java/tmg/flashback/FlashbackStartup.kt
+++ b/app/src/main/java/tmg/flashback/FlashbackStartup.kt
@@ -21,6 +21,7 @@ import tmg.flashback.googleanalytics.manager.FirebaseAnalyticsManager
 import tmg.flashback.configuration.usecases.InitialiseConfigUseCase
 import tmg.flashback.crashlytics.model.FirebaseKey
 import tmg.flashback.crashlytics.services.FirebaseCrashService
+import tmg.flashback.crashlytics.usecases.AddCustomKeyUseCase
 import tmg.flashback.crashlytics.usecases.InitialiseCrashReportingUseCase
 import tmg.flashback.device.managers.BuildConfigManager
 import tmg.flashback.device.repository.DeviceRepository
@@ -69,7 +70,7 @@ class FlashbackStartup @Inject constructor(
     private val themeRepository: ThemeRepository,
     private val buildConfigManager: BuildConfigManager,
     private val firebaseAnalyticsManager: FirebaseAnalyticsManager,
-    private val firebaseCrashService: FirebaseCrashService,
+    private val addCustomKeyUseCase: AddCustomKeyUseCase,
     private val initialiseConfigUseCase: InitialiseConfigUseCase,
     private val systemNotificationManager: SystemNotificationManager,
     private val remoteNotificationSubscribeUseCase: RemoteNotificationSubscribeUseCase,
@@ -199,7 +200,7 @@ class FlashbackStartup @Inject constructor(
 
         applicationScope.launch(Dispatchers.IO) {
             appOpenedUseCase.preload()
-            firebaseCrashService.setCustomKey(FirebaseKey.InstallationId, deviceRepository.installationId)
+            addCustomKeyUseCase(FirebaseKey.InstallationId, deviceRepository.installationId)
         }
 
         // Update Widgets

--- a/app/src/main/java/tmg/flashback/managers/buildconfig/AppBuildConfigManager.kt
+++ b/app/src/main/java/tmg/flashback/managers/buildconfig/AppBuildConfigManager.kt
@@ -41,4 +41,31 @@ class AppBuildConfigManager @Inject constructor() : BuildConfigManager {
                 || Build.PRODUCT.contains("vbox86p")
                 || Build.PRODUCT.contains("emulator")
                 || Build.PRODUCT.contains("simulator")
+
+    override val isDebug: Boolean
+        get() = BuildConfig.DEBUG
+
+    override val brand: String
+        get() = Build.BRAND
+
+    override val hardware: String
+        get() = Build.HARDWARE
+
+    override val board: String
+        get() = Build.BOARD
+
+    override val fingerprint: String
+        get() = Build.FINGERPRINT
+
+    override val model: String
+        get() = Build.MODEL
+
+    override val manufacturer: String
+        get() = Build.MANUFACTURER
+
+    override val product: String
+        get() = Build.PRODUCT
+
+    override val device: String
+        get() = Build.DEVICE
 }

--- a/core/device/src/main/java/tmg/flashback/device/managers/BuildConfigManager.kt
+++ b/core/device/src/main/java/tmg/flashback/device/managers/BuildConfigManager.kt
@@ -17,4 +17,22 @@ interface BuildConfigManager {
     val isRuntimeNotificationsSupported: Boolean
 
     val isEmulator: Boolean
+
+    val isDebug: Boolean
+
+    val brand: String
+
+    val hardware: String
+
+    val board: String
+
+    val fingerprint: String
+
+    val model: String
+
+    val manufacturer: String
+
+    val product: String
+
+    val device: String
 }

--- a/core/metrics/crashlytics/src/main/java/tmg/flashback/crashlytics/di/CrashReportingModule.kt
+++ b/core/metrics/crashlytics/src/main/java/tmg/flashback/crashlytics/di/CrashReportingModule.kt
@@ -16,7 +16,6 @@ import tmg.flashback.crashlytics.services.FirebaseFirebaseCrashServiceImpl
 internal abstract class CrashReportingModule {
 
     @Binds
-    abstract fun bindCrashService(impl: FirebaseFirebaseCrashServiceImpl): FirebaseCrashService
 }
 
 @EntryPoint
@@ -29,4 +28,5 @@ interface CrashModule {
             return EntryPoints.get(context.applicationContext, CrashModule::class.java)
         }
     }
+    abstract fun bindCrashService(impl: FirebaseCrashServiceImpl): FirebaseCrashService
 }

--- a/core/metrics/crashlytics/src/main/java/tmg/flashback/crashlytics/di/CrashReportingModule.kt
+++ b/core/metrics/crashlytics/src/main/java/tmg/flashback/crashlytics/di/CrashReportingModule.kt
@@ -1,32 +1,16 @@
 package tmg.flashback.crashlytics.di
 
-import android.content.Context
 import dagger.Binds
 import dagger.Module
-import dagger.hilt.EntryPoint
-import dagger.hilt.EntryPoints
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import tmg.flashback.crashlytics.manager.CrashlyticsManager
 import tmg.flashback.crashlytics.services.FirebaseCrashService
-import tmg.flashback.crashlytics.services.FirebaseFirebaseCrashServiceImpl
+import tmg.flashback.crashlytics.services.FirebaseCrashServiceImpl
 
 @Module
 @InstallIn(SingletonComponent::class)
 internal abstract class CrashReportingModule {
 
     @Binds
-}
-
-@EntryPoint
-@InstallIn(SingletonComponent::class)
-interface CrashModule {
-    fun crashManager(): CrashlyticsManager
-
-    companion object {
-        fun entryPoints(context: Context): CrashModule {
-            return EntryPoints.get(context.applicationContext, CrashModule::class.java)
-        }
-    }
     abstract fun bindCrashService(impl: FirebaseCrashServiceImpl): FirebaseCrashService
 }

--- a/core/metrics/crashlytics/src/main/java/tmg/flashback/crashlytics/manager/CrashlyticsManager.kt
+++ b/core/metrics/crashlytics/src/main/java/tmg/flashback/crashlytics/manager/CrashlyticsManager.kt
@@ -9,12 +9,12 @@ import javax.inject.Singleton
 
 @Singleton
 class CrashlyticsManager @Inject constructor(
-    private val crashRepository: PrivacyRepository,
+    private val privacyRepository: PrivacyRepository,
     private val firebaseCrashService: FirebaseCrashService
 ) {
 
     private val enabled
-        get() = crashRepository.crashReporting
+        get() = privacyRepository.crashReporting
 
     fun logError(msg: String) {
         if (enabled) {

--- a/core/metrics/crashlytics/src/main/java/tmg/flashback/crashlytics/services/FirebaseCrashService.kt
+++ b/core/metrics/crashlytics/src/main/java/tmg/flashback/crashlytics/services/FirebaseCrashService.kt
@@ -7,12 +7,10 @@ import tmg.flashback.crashlytics.model.FirebaseKey
  * Abstracted for testing
  */
 interface FirebaseCrashService {
-    fun initialise(
-        enableCrashReporting: Boolean,
-        deviceUuid: String,
-        extraKeys: Map<FirebaseKey, String>
-    )
+    fun setCrashlyticsCollectionEnabled(enabled: Boolean)
     fun setCustomKey(key: FirebaseKey, value: String)
+    fun setCustomKey(key: FirebaseKey, value: Boolean)
+    fun setUserId(userId: String)
     fun logInfo(msg: String)
     fun logError(msg: String)
     fun logException(error: Exception, context: String)

--- a/core/metrics/crashlytics/src/main/java/tmg/flashback/crashlytics/services/FirebaseCrashServiceImpl.kt
+++ b/core/metrics/crashlytics/src/main/java/tmg/flashback/crashlytics/services/FirebaseCrashServiceImpl.kt
@@ -8,7 +8,7 @@ import tmg.flashback.crashlytics.model.FirebaseKey
 import tmg.flashback.device.managers.BuildConfigManager
 import javax.inject.Inject
 
-internal class FirebaseFirebaseCrashServiceImpl @Inject constructor(
+internal class FirebaseCrashServiceImpl @Inject constructor(
     private val buildConfigManager: BuildConfigManager
 ): FirebaseCrashService {
 
@@ -26,7 +26,7 @@ internal class FirebaseFirebaseCrashServiceImpl @Inject constructor(
     ) {
         val instance = FirebaseCrashlytics.getInstance()
 
-        instance.setCrashlyticsCollectionEnabled(enableCrashReporting)
+        instance.isCrashlyticsCollectionEnabled = enableCrashReporting
         if (enableCrashReporting) {
             Log.i("Crashlytics", "Enabling crashlytics")
         }

--- a/core/metrics/crashlytics/src/main/java/tmg/flashback/crashlytics/usecases/AddCustomKeyUseCase.kt
+++ b/core/metrics/crashlytics/src/main/java/tmg/flashback/crashlytics/usecases/AddCustomKeyUseCase.kt
@@ -1,0 +1,16 @@
+package tmg.flashback.crashlytics.usecases
+
+import tmg.flashback.crashlytics.model.FirebaseKey
+import tmg.flashback.crashlytics.services.FirebaseCrashService
+import javax.inject.Inject
+
+class AddCustomKeyUseCase @Inject constructor(
+    private val firebaseCrashService: FirebaseCrashService
+) {
+    operator fun invoke(key: FirebaseKey, value: String) {
+        firebaseCrashService.setCustomKey(key, value)
+    }
+    operator fun invoke(key: FirebaseKey, value: Boolean) {
+        firebaseCrashService.setCustomKey(key, value)
+    }
+}

--- a/core/metrics/crashlytics/src/main/java/tmg/flashback/crashlytics/usecases/InitialiseCrashReportingUseCase.kt
+++ b/core/metrics/crashlytics/src/main/java/tmg/flashback/crashlytics/usecases/InitialiseCrashReportingUseCase.kt
@@ -1,22 +1,43 @@
 package tmg.flashback.crashlytics.usecases
 
+import android.util.Log
 import tmg.flashback.crashlytics.model.FirebaseKey
 import tmg.flashback.crashlytics.services.FirebaseCrashService
+import tmg.flashback.device.managers.BuildConfigManager
 import tmg.flashback.device.repository.PrivacyRepository
 import javax.inject.Inject
 
 class InitialiseCrashReportingUseCase @Inject constructor(
     private val privacyRepository: PrivacyRepository,
-    private val firebaseCrashService: FirebaseCrashService
+    private val firebaseCrashService: FirebaseCrashService,
+    private val buildConfigManager: BuildConfigManager
 ) {
     fun initialise(
         deviceUuid: String,
         extraKeys: Map<FirebaseKey, String>,
     ) {
-        firebaseCrashService.initialise(
-            enableCrashReporting = privacyRepository.crashReporting,
-            deviceUuid = deviceUuid,
-            extraKeys = extraKeys,
-        )
+        firebaseCrashService.setCrashlyticsCollectionEnabled(privacyRepository.crashReporting)
+        when (privacyRepository.crashReporting) {
+            true -> Log.i("Crashlytics", "Enabling crashlytics")
+            false -> Log.i("Crashlytics", "Disabling crashlytics")
+        }
+
+        firebaseCrashService.setCustomKey(FirebaseKey.Emulator, buildConfigManager.isEmulator)
+        firebaseCrashService.setCustomKey(FirebaseKey.Debug, buildConfigManager.isDebug)
+
+        firebaseCrashService.setUserId(deviceUuid)
+        firebaseCrashService.setCustomKey(FirebaseKey.DeviceUuid, deviceUuid)
+        firebaseCrashService.setCustomKey(FirebaseKey.Brand, buildConfigManager.brand)
+        firebaseCrashService.setCustomKey(FirebaseKey.Hardware, buildConfigManager.hardware)
+        firebaseCrashService.setCustomKey(FirebaseKey.Board, buildConfigManager.board)
+        firebaseCrashService.setCustomKey(FirebaseKey.Fingerprint, buildConfigManager.fingerprint)
+        firebaseCrashService.setCustomKey(FirebaseKey.Model, buildConfigManager.model)
+        firebaseCrashService.setCustomKey(FirebaseKey.Manufacturer, buildConfigManager.manufacturer)
+        firebaseCrashService.setCustomKey(FirebaseKey.Product, buildConfigManager.product)
+        firebaseCrashService.setCustomKey(FirebaseKey.Device, buildConfigManager.device)
+
+        extraKeys.forEach { (key, value) ->
+            firebaseCrashService.setCustomKey(key, value)
+        }
     }
 }

--- a/core/metrics/crashlytics/src/test/java/tmg/flashback/crashlytics/usecases/AddCustomKeyUseCaseTest.kt
+++ b/core/metrics/crashlytics/src/test/java/tmg/flashback/crashlytics/usecases/AddCustomKeyUseCaseTest.kt
@@ -1,0 +1,40 @@
+package tmg.flashback.crashlytics.usecases
+
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import tmg.flashback.crashlytics.model.FirebaseKey
+import tmg.flashback.crashlytics.services.FirebaseCrashService
+
+internal class AddCustomKeyUseCaseTest {
+
+    private val mockFirebaseCrashService: FirebaseCrashService = mockk(relaxed = true)
+
+    private lateinit var underTest: AddCustomKeyUseCase
+
+    private fun initUnderTest() {
+        underTest = AddCustomKeyUseCase(
+            firebaseCrashService = mockFirebaseCrashService
+        )
+    }
+
+    @Test
+    fun `setting string value calls service`() {
+        initUnderTest()
+        underTest.invoke(FirebaseKey.AppFirstOpen, "value")
+
+        verify {
+            mockFirebaseCrashService.setCustomKey(FirebaseKey.AppFirstOpen, "value")
+        }
+    }
+
+    @Test
+    fun `setting boolean value calls service`() {
+        initUnderTest()
+        underTest.invoke(FirebaseKey.AppFirstOpen, false)
+
+        verify {
+            mockFirebaseCrashService.setCustomKey(FirebaseKey.AppFirstOpen, false)
+        }
+    }
+}

--- a/core/metrics/googleanalytics/src/main/java/tmg/flashback/googleanalytics/di/AnalyticsModule.kt
+++ b/core/metrics/googleanalytics/src/main/java/tmg/flashback/googleanalytics/di/AnalyticsModule.kt
@@ -4,13 +4,13 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import tmg.flashback.googleanalytics.services.FireabseAnalyticsService
-import tmg.flashback.googleanalytics.services.FirebaseFireabseAnalyticsServiceImpl
+import tmg.flashback.googleanalytics.services.FirebaseAnalyticsService
+import tmg.flashback.googleanalytics.services.FirebaseAnalyticsServiceImpl
 
 @Module
 @InstallIn(SingletonComponent::class)
 internal abstract class AnalyticsModule {
 
     @Binds
-    abstract fun bindsAnalyticsService(impl: FirebaseFireabseAnalyticsServiceImpl): FireabseAnalyticsService
+    abstract fun bindsAnalyticsService(impl: FirebaseAnalyticsServiceImpl): FirebaseAnalyticsService
 }

--- a/core/metrics/googleanalytics/src/main/java/tmg/flashback/googleanalytics/manager/FirebaseAnalyticsManager.kt
+++ b/core/metrics/googleanalytics/src/main/java/tmg/flashback/googleanalytics/manager/FirebaseAnalyticsManager.kt
@@ -2,7 +2,7 @@ package tmg.flashback.googleanalytics.manager
 
 import android.os.Bundle
 import tmg.flashback.googleanalytics.UserProperty
-import tmg.flashback.googleanalytics.services.FireabseAnalyticsService
+import tmg.flashback.googleanalytics.services.FirebaseAnalyticsService
 import tmg.flashback.device.repository.PrivacyRepository
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -10,7 +10,7 @@ import javax.inject.Singleton
 @Singleton
 class FirebaseAnalyticsManager @Inject constructor(
     private val privacyRepository: PrivacyRepository,
-    private val fireabseAnalyticsService: FireabseAnalyticsService
+    private val firebaseAnalyticsService: FirebaseAnalyticsService
 ) {
     var enabled: Boolean
         get() = privacyRepository.analytics
@@ -19,8 +19,8 @@ class FirebaseAnalyticsManager @Inject constructor(
         }
 
     fun initialise(userId: String) {
-        fireabseAnalyticsService.setUserId(userId)
-        fireabseAnalyticsService.setAnalyticsCollectionEnabled(enabled)
+        firebaseAnalyticsService.setUserId(userId)
+        firebaseAnalyticsService.setAnalyticsCollectionEnabled(enabled)
     }
 
     fun logEvent(key: String, params: Map<String, String> = emptyMap()) {
@@ -31,23 +31,23 @@ class FirebaseAnalyticsManager @Inject constructor(
                         putString(x.key, x.value)
                     }
                 }
-                fireabseAnalyticsService.logEvent(key, bundle)
+                firebaseAnalyticsService.logEvent(key, bundle)
             }
             else {
-                fireabseAnalyticsService.logEvent(key)
+                firebaseAnalyticsService.logEvent(key)
             }
         }
     }
 
     fun setUserProperty(property: UserProperty, value: String) {
         if (enabled) {
-            fireabseAnalyticsService.setProperty(property.key, value)
+            firebaseAnalyticsService.setProperty(property.key, value)
         }
     }
 
     fun viewScreen(screenName: String, params: Map<String, String> = emptyMap(), clazz: Class<*>? = null) {
         if (enabled) {
-            fireabseAnalyticsService.logViewScreen(screenName, params, clazz)
+            firebaseAnalyticsService.logViewScreen(screenName, params, clazz)
         }
     }
 }

--- a/core/metrics/googleanalytics/src/main/java/tmg/flashback/googleanalytics/services/FirebaseAnalyticsService.kt
+++ b/core/metrics/googleanalytics/src/main/java/tmg/flashback/googleanalytics/services/FirebaseAnalyticsService.kt
@@ -6,7 +6,7 @@ import android.os.Bundle
  * Wrapper around the Firebase Analytics package that we use
  * Abstracted for testing
  */
-interface FireabseAnalyticsService {
+interface FirebaseAnalyticsService {
 
     fun setProperty(key: String, value: String)
 

--- a/core/metrics/googleanalytics/src/main/java/tmg/flashback/googleanalytics/services/FirebaseAnalyticsServiceImpl.kt
+++ b/core/metrics/googleanalytics/src/main/java/tmg/flashback/googleanalytics/services/FirebaseAnalyticsServiceImpl.kt
@@ -8,10 +8,10 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import tmg.flashback.googleanalytics.BuildConfig
 import javax.inject.Inject
 
-internal class FirebaseFireabseAnalyticsServiceImpl @Inject constructor(
+internal class FirebaseAnalyticsServiceImpl @Inject constructor(
     @ApplicationContext
     private val context: Context
-): FireabseAnalyticsService {
+): FirebaseAnalyticsService {
 
     private val analytics: FirebaseAnalytics = FirebaseAnalytics.getInstance(context)
 

--- a/core/metrics/googleanalytics/src/test/java/tmg/flashback/googleanalytics/manager/FirebaseAnalyticsManagerTest.kt
+++ b/core/metrics/googleanalytics/src/test/java/tmg/flashback/googleanalytics/manager/FirebaseAnalyticsManagerTest.kt
@@ -7,18 +7,18 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import tmg.flashback.googleanalytics.UserProperty
 import tmg.flashback.device.repository.PrivacyRepository
-import tmg.flashback.googleanalytics.services.FireabseAnalyticsService
+import tmg.flashback.googleanalytics.services.FirebaseAnalyticsService
 
 
 internal class FirebaseAnalyticsManagerTest {
 
     private val mockPrivacyRepository: PrivacyRepository = mockk(relaxed = true)
-    private val mockFireabseAnalyticsService: FireabseAnalyticsService = mockk(relaxed = true)
+    private val mockFirebaseAnalyticsService: FirebaseAnalyticsService = mockk(relaxed = true)
 
     private lateinit var sut: FirebaseAnalyticsManager
 
     private fun initSUT() {
-        sut = FirebaseAnalyticsManager(mockPrivacyRepository, mockFireabseAnalyticsService)
+        sut = FirebaseAnalyticsManager(mockPrivacyRepository, mockFirebaseAnalyticsService)
     }
 
     //region enabled
@@ -58,8 +58,8 @@ internal class FirebaseAnalyticsManagerTest {
         initSUT()
         sut.initialise("my-user-id")
         verify {
-            mockFireabseAnalyticsService.setUserId("my-user-id")
-            mockFireabseAnalyticsService.setAnalyticsCollectionEnabled(true)
+            mockFirebaseAnalyticsService.setUserId("my-user-id")
+            mockFirebaseAnalyticsService.setAnalyticsCollectionEnabled(true)
         }
     }
 
@@ -76,7 +76,7 @@ internal class FirebaseAnalyticsManagerTest {
         sut.logEvent("testKey")
 
         verify {
-            mockFireabseAnalyticsService.logEvent("testKey")
+            mockFirebaseAnalyticsService.logEvent("testKey")
         }
     }
 
@@ -88,7 +88,7 @@ internal class FirebaseAnalyticsManagerTest {
         sut.logEvent("testKey", mapOf("test" to "hello"))
 
         verify {
-            mockFireabseAnalyticsService.logEvent("testKey", any())
+            mockFirebaseAnalyticsService.logEvent("testKey", any())
         }
     }
 
@@ -101,7 +101,7 @@ internal class FirebaseAnalyticsManagerTest {
         sut.logEvent("testKey")
 
         verify(exactly = 0) {
-            mockFireabseAnalyticsService.logEvent("testKey")
+            mockFirebaseAnalyticsService.logEvent("testKey")
         }
     }
 
@@ -118,7 +118,7 @@ internal class FirebaseAnalyticsManagerTest {
         sut.setUserProperty(UserProperty.APP_VERSION, "test-value")
 
         verify {
-            mockFireabseAnalyticsService.setProperty(any(), any())
+            mockFirebaseAnalyticsService.setProperty(any(), any())
         }
     }
 
@@ -131,7 +131,7 @@ internal class FirebaseAnalyticsManagerTest {
         sut.setUserProperty(UserProperty.APP_VERSION, "test-value")
 
         verify(exactly = 0) {
-            mockFireabseAnalyticsService.setProperty(any(), any())
+            mockFirebaseAnalyticsService.setProperty(any(), any())
         }
     }
 
@@ -148,7 +148,7 @@ internal class FirebaseAnalyticsManagerTest {
         sut.viewScreen("screen", emptyMap(), this.javaClass)
 
         verify {
-            mockFireabseAnalyticsService.logViewScreen(any(), any(), any())
+            mockFirebaseAnalyticsService.logViewScreen(any(), any(), any())
         }
     }
 
@@ -161,7 +161,7 @@ internal class FirebaseAnalyticsManagerTest {
         sut.viewScreen("screen", emptyMap(), this.javaClass)
 
         verify(exactly = 0) {
-            mockFireabseAnalyticsService.logViewScreen(any(), any(), any())
+            mockFirebaseAnalyticsService.logViewScreen(any(), any(), any())
         }
     }
 

--- a/presentation/style/src/main/java/tmg/flashback/style/Theme.kt
+++ b/presentation/style/src/main/java/tmg/flashback/style/Theme.kt
@@ -93,11 +93,13 @@ sealed class SupportedTheme{
         val darkColors: AppColors = darkColours
     }
 
-    @RequiresApi(Build.VERSION_CODES.S)
     object MaterialYou: SupportedTheme() {
+        @RequiresApi(Build.VERSION_CODES.S)
         fun lightColors(context: Context): AppColors {
             return lightColours.dynamic(dynamicLightColorScheme(context), isLightMode = true)
         }
+
+        @RequiresApi(Build.VERSION_CODES.S)
         fun darkColors(context: Context): AppColors {
             return darkColours.dynamic(dynamicDarkColorScheme(context), isLightMode = false)
         }

--- a/presentation/ui/src/main/java/tmg/flashback/ui/components/flag/Flag.kt
+++ b/presentation/ui/src/main/java/tmg/flashback/ui/components/flag/Flag.kt
@@ -1,11 +1,9 @@
 package tmg.flashback.ui.components.flag
 
-import android.content.res.Resources.NotFoundException
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -13,7 +11,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import com.murgupluoglu.flagkit.R.drawable
-import tmg.flashback.crashlytics.di.CrashModule
 import tmg.flashback.style.AppTheme
 import tmg.flashback.style.AppThemePreview
 import tmg.flashback.style.annotations.PreviewTheme
@@ -47,10 +44,6 @@ fun Flag(
                     this.contentDescription = nationality ?: iso
                 }
         )
-        DisposableEffect(key1 = Unit, effect = {
-            CrashModule.entryPoints(context).crashManager().logException(NotFoundException("Flag resource for '$iso' ($nationality) not found!"))
-            return@DisposableEffect onDispose {  }
-        })
     }
 }
 


### PR DESCRIPTION
- Removes duplicated FirebaseFirebase naming
- Simplifies FirebaseCrashService to be wrapper around library
- Expanded crashlytics init use case to do full init + more test coverage