### PR TITLE
Keep last season option

### DIFF
--- a/app/src/main/java/tmg/flashback/presentation/settings/Settings.kt
+++ b/app/src/main/java/tmg/flashback/presentation/settings/Settings.kt
@@ -79,6 +79,16 @@ object Settings {
             isEnabled = isEnabled
         )
 
+        const val rememberSeasonChange = "remember_season_change"
+        fun rememberSeasonChange(isChecked: Boolean, isEnabled: Boolean = true) = Setting.Switch(
+            _key = rememberSeasonChange,
+            title = string.settings_pref_remember_season_change_title,
+            subtitle = string.settings_pref_remember_season_change_description,
+            isBeta = true,
+            isChecked = isChecked,
+            isEnabled = isEnabled
+        )
+
         val weather = Setting.Section(
             _key = "weather",
             title = string.settings_section_weather_title,

--- a/app/src/main/java/tmg/flashback/presentation/settings/data/SettingsLayoutScreen.kt
+++ b/app/src/main/java/tmg/flashback/presentation/settings/data/SettingsLayoutScreen.kt
@@ -32,6 +32,7 @@ fun SettingsLayoutScreenVM(
     val collapsedList = viewModel.outputs.collapsedListEnabled.collectAsState()
     val emptyWeeksInSchedule = viewModel.outputs.emptyWeeksInSchedule.collectAsState()
     val showRecentHighlights = viewModel.outputs.recentHighlights.collectAsState()
+    val rememberSeasonChange = viewModel.outputs.rememberSeasonChange.collectAsState()
     SettingsLayoutScreen(
         actionUpClicked = actionUpClicked,
         windowSizeClass = windowSizeClass,
@@ -39,7 +40,8 @@ fun SettingsLayoutScreenVM(
         prefClicked = viewModel.inputs::prefClicked,
         collapsedListEnabled = collapsedList.value,
         showEmptyWeeksInSchedule = emptyWeeksInSchedule.value,
-        showRecentHighlights = showRecentHighlights.value
+        showRecentHighlights = showRecentHighlights.value,
+        rememberSeasonChange = rememberSeasonChange.value
     )
 }
 
@@ -51,7 +53,8 @@ fun SettingsLayoutScreen(
     prefClicked: (Setting) -> Unit,
     collapsedListEnabled: Boolean,
     showEmptyWeeksInSchedule: Boolean,
-    showRecentHighlights: Boolean
+    showRecentHighlights: Boolean,
+    rememberSeasonChange: Boolean
 ) {
     LazyColumn(
         contentPadding = paddingValues,
@@ -77,6 +80,10 @@ fun SettingsLayoutScreen(
                 model = Settings.Data.showEmptyWeeksInSchedule(showEmptyWeeksInSchedule),
                 onClick = prefClicked
             )
+            Switch(
+                model = Settings.Data.rememberSeasonChange(rememberSeasonChange),
+                onClick = prefClicked
+            )
 
             Footer()
         }
@@ -94,7 +101,8 @@ private fun Preview() {
             prefClicked = {},
             collapsedListEnabled = true,
             showEmptyWeeksInSchedule = false,
-            showRecentHighlights = true
+            showRecentHighlights = true,
+            rememberSeasonChange = true
         )
     }
 }

--- a/app/src/main/java/tmg/flashback/presentation/settings/data/SettingsLayoutViewModel.kt
+++ b/app/src/main/java/tmg/flashback/presentation/settings/data/SettingsLayoutViewModel.kt
@@ -31,7 +31,7 @@ class SettingsLayoutViewModel @Inject constructor(
     override val collapsedListEnabled: MutableStateFlow<Boolean> = MutableStateFlow(homeRepository.collapseList)
     override val emptyWeeksInSchedule: MutableStateFlow<Boolean> = MutableStateFlow(homeRepository.emptyWeeksInSchedule)
     override val recentHighlights: MutableStateFlow<Boolean> = MutableStateFlow(homeRepository.recentHighlights)
-    override val rememberSeasonChange: MutableStateFlow<Boolean> = MutableStateFlow(homeRepository.rememberSeasonChange)
+    override val rememberSeasonChange: MutableStateFlow<Boolean> = MutableStateFlow(homeRepository.keepUserSelectedSeason)
 
     override fun prefClicked(pref: Setting) {
         when (pref.key) {
@@ -48,8 +48,8 @@ class SettingsLayoutViewModel @Inject constructor(
                 recentHighlights.value = homeRepository.recentHighlights
             }
             Settings.Data.rememberSeasonChange -> {
-                homeRepository.rememberSeasonChange = !homeRepository.rememberSeasonChange
-                rememberSeasonChange.value = homeRepository.rememberSeasonChange
+                homeRepository.keepUserSelectedSeason = !homeRepository.keepUserSelectedSeason
+                rememberSeasonChange.value = homeRepository.keepUserSelectedSeason
             }
         }
     }

--- a/app/src/main/java/tmg/flashback/presentation/settings/data/SettingsLayoutViewModel.kt
+++ b/app/src/main/java/tmg/flashback/presentation/settings/data/SettingsLayoutViewModel.kt
@@ -17,6 +17,7 @@ interface SettingsLayoutViewModelOutputs {
     val collapsedListEnabled: StateFlow<Boolean>
     val emptyWeeksInSchedule: StateFlow<Boolean>
     val recentHighlights: StateFlow<Boolean>
+    val rememberSeasonChange: StateFlow<Boolean>
 }
 
 @HiltViewModel
@@ -30,6 +31,7 @@ class SettingsLayoutViewModel @Inject constructor(
     override val collapsedListEnabled: MutableStateFlow<Boolean> = MutableStateFlow(homeRepository.collapseList)
     override val emptyWeeksInSchedule: MutableStateFlow<Boolean> = MutableStateFlow(homeRepository.emptyWeeksInSchedule)
     override val recentHighlights: MutableStateFlow<Boolean> = MutableStateFlow(homeRepository.recentHighlights)
+    override val rememberSeasonChange: MutableStateFlow<Boolean> = MutableStateFlow(homeRepository.rememberSeasonChange)
 
     override fun prefClicked(pref: Setting) {
         when (pref.key) {
@@ -44,6 +46,10 @@ class SettingsLayoutViewModel @Inject constructor(
             Settings.Data.recentHighlights -> {
                 homeRepository.recentHighlights = !homeRepository.recentHighlights
                 recentHighlights.value = homeRepository.recentHighlights
+            }
+            Settings.Data.rememberSeasonChange -> {
+                homeRepository.rememberSeasonChange = !homeRepository.rememberSeasonChange
+                rememberSeasonChange.value = homeRepository.rememberSeasonChange
             }
         }
     }

--- a/app/src/test/java/tmg/flashback/presentation/settings/data/SettingsLayoutViewModelTest.kt
+++ b/app/src/test/java/tmg/flashback/presentation/settings/data/SettingsLayoutViewModelTest.kt
@@ -124,4 +124,39 @@ internal class SettingsLayoutViewModelTest: BaseTest() {
         }
         underTest.outputs.recentHighlights.test { awaitItem() }
     }
+
+
+    @Test
+    fun `remember season change is true when pref is true`() = runTest(testDispatcher) {
+        every { mockHomeRepository.rememberSeasonChange } returns true
+
+        initUnderTest()
+        underTest.outputs.rememberSeasonChange.test {
+            assertEquals(true, awaitItem())
+        }
+    }
+
+    @Test
+    fun `remember season change is false when pref is false`() = runTest(testDispatcher) {
+        every { mockHomeRepository.rememberSeasonChange } returns false
+
+        initUnderTest()
+        underTest.outputs.rememberSeasonChange.test {
+            assertEquals(false, awaitItem())
+        }
+    }
+
+    @Test
+    fun `click show remember season change updates pref and updates value`() = runTest(testDispatcher) {
+        every { mockHomeRepository.rememberSeasonChange } returns false
+
+        initUnderTest()
+        underTest.outputs.rememberSeasonChange.test { awaitItem() }
+        underTest.inputs.prefClicked(Settings.Data.rememberSeasonChange(true))
+
+        verify {
+            mockHomeRepository.rememberSeasonChange = true
+        }
+        underTest.outputs.rememberSeasonChange.test { awaitItem() }
+    }
 }

--- a/app/src/test/java/tmg/flashback/presentation/settings/data/SettingsLayoutViewModelTest.kt
+++ b/app/src/test/java/tmg/flashback/presentation/settings/data/SettingsLayoutViewModelTest.kt
@@ -128,7 +128,7 @@ internal class SettingsLayoutViewModelTest: BaseTest() {
 
     @Test
     fun `remember season change is true when pref is true`() = runTest(testDispatcher) {
-        every { mockHomeRepository.rememberSeasonChange } returns true
+        every { mockHomeRepository.keepUserSelectedSeason } returns true
 
         initUnderTest()
         underTest.outputs.rememberSeasonChange.test {
@@ -138,7 +138,7 @@ internal class SettingsLayoutViewModelTest: BaseTest() {
 
     @Test
     fun `remember season change is false when pref is false`() = runTest(testDispatcher) {
-        every { mockHomeRepository.rememberSeasonChange } returns false
+        every { mockHomeRepository.keepUserSelectedSeason } returns false
 
         initUnderTest()
         underTest.outputs.rememberSeasonChange.test {
@@ -148,14 +148,14 @@ internal class SettingsLayoutViewModelTest: BaseTest() {
 
     @Test
     fun `click show remember season change updates pref and updates value`() = runTest(testDispatcher) {
-        every { mockHomeRepository.rememberSeasonChange } returns false
+        every { mockHomeRepository.keepUserSelectedSeason } returns false
 
         initUnderTest()
         underTest.outputs.rememberSeasonChange.test { awaitItem() }
         underTest.inputs.prefClicked(Settings.Data.rememberSeasonChange(true))
 
         verify {
-            mockHomeRepository.rememberSeasonChange = true
+            mockHomeRepository.keepUserSelectedSeason = true
         }
         underTest.outputs.rememberSeasonChange.test { awaitItem() }
     }

--- a/feature/season/src/main/java/tmg/flashback/season/presentation/dashboard/shared/seasonpicker/CurrentSeasonHolder.kt
+++ b/feature/season/src/main/java/tmg/flashback/season/presentation/dashboard/shared/seasonpicker/CurrentSeasonHolder.kt
@@ -1,12 +1,7 @@
 package tmg.flashback.season.presentation.dashboard.shared.seasonpicker
 
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
-import tmg.flashback.formula1.constants.Formula1.currentSeasonYear
 import tmg.flashback.season.repository.HomeRepository
 import tmg.flashback.season.usecases.DefaultSeasonUseCase
 import javax.inject.Inject
@@ -40,7 +35,7 @@ class CurrentSeasonHolder @Inject constructor(
 
     fun updateTo(season: Int) {
         homeRepository.viewedSeasons = (homeRepository.viewedSeasons + season)
-        homeRepository.userSeasonChange = season
+        homeRepository.userSelectedSeason = season
         if (supportedSeasons.contains(season)) {
             _currentSeason.value = season
         }

--- a/feature/season/src/main/java/tmg/flashback/season/presentation/dashboard/shared/seasonpicker/CurrentSeasonHolder.kt
+++ b/feature/season/src/main/java/tmg/flashback/season/presentation/dashboard/shared/seasonpicker/CurrentSeasonHolder.kt
@@ -40,6 +40,7 @@ class CurrentSeasonHolder @Inject constructor(
 
     fun updateTo(season: Int) {
         homeRepository.viewedSeasons = (homeRepository.viewedSeasons + season)
+        homeRepository.userSeasonChange = season
         if (supportedSeasons.contains(season)) {
             _currentSeason.value = season
         }

--- a/feature/season/src/main/java/tmg/flashback/season/repository/HomeRepository.kt
+++ b/feature/season/src/main/java/tmg/flashback/season/repository/HomeRepository.kt
@@ -33,6 +33,7 @@ class HomeRepository @Inject constructor(
         private const val keySeenSeasons: String = "SEASONS_VIEWED"
         private const val keyDashboardCollapseList: String = "DASHBOARD_COLLAPSE_LIST"
         private const val keyProvidedByAtTop: String = "PROVIDED_BY_AT_TOP"
+        private const val keyRememberSeasonChange: String = "REMEMBER_SEASON_CHANGE"
 
         private const val keySeasonOnboarding: String = "ONBOARDING_SEASON"
     }
@@ -96,6 +97,13 @@ class HomeRepository @Inject constructor(
         get() = preferenceManager.getBoolean(keyRecentHighlights, true)
         set(value) = preferenceManager.save(keyRecentHighlights, value)
 
+
+    /**
+     * Remembering season change
+     */
+    var rememberSeasonChange: Boolean
+        get() = preferenceManager.getBoolean(keyRememberSeasonChange, false)
+        set(value) = preferenceManager.save(keyRememberSeasonChange, value)
 
     /**
      * Default to which tab

--- a/feature/season/src/main/java/tmg/flashback/season/repository/HomeRepository.kt
+++ b/feature/season/src/main/java/tmg/flashback/season/repository/HomeRepository.kt
@@ -34,6 +34,7 @@ class HomeRepository @Inject constructor(
         private const val keyDashboardCollapseList: String = "DASHBOARD_COLLAPSE_LIST"
         private const val keyProvidedByAtTop: String = "PROVIDED_BY_AT_TOP"
         private const val keyRememberSeasonChange: String = "REMEMBER_SEASON_CHANGE"
+        private const val keyUserSeasonChange: String = "USER_SEASON_CHANGE"
 
         private const val keySeasonOnboarding: String = "ONBOARDING_SEASON"
     }
@@ -99,11 +100,15 @@ class HomeRepository @Inject constructor(
 
 
     /**
-     * Remembering season change
+     * Remembering a season change
      */
     var rememberSeasonChange: Boolean
         get() = preferenceManager.getBoolean(keyRememberSeasonChange, false)
         set(value) = preferenceManager.save(keyRememberSeasonChange, value)
+
+    var userSeasonChange: Int?
+        get() = preferenceManager.getInt(keyUserSeasonChange, -1).takeIf { it != -1 }
+        set(value) = preferenceManager.save(keyUserSeasonChange, value ?: -1)
 
     /**
      * Default to which tab

--- a/feature/season/src/main/java/tmg/flashback/season/repository/HomeRepository.kt
+++ b/feature/season/src/main/java/tmg/flashback/season/repository/HomeRepository.kt
@@ -40,11 +40,10 @@ class HomeRepository @Inject constructor(
     }
 
     /**
-     * Default year as specified by the server.
+     * Is the searching of the statistics functionality enabled server side
      */
-    val serverDefaultYear: Int by lazy {
-        configManager.getString(keyDefaultYear)?.toIntOrNull() ?: Year.now().value
-    }
+    val searchEnabled: Boolean
+        get() = configManager.getBoolean(keySearch)
 
     /**
      * Banner to be displayed at the top of the screen
@@ -59,6 +58,14 @@ class HomeRepository @Inject constructor(
      */
     val dataProvidedBy: String?
         get() = configManager.getString(keyDataProvidedBy)
+
+
+    /**
+     * Default year as specified by the server.
+     */
+    val defaultSeason: Int by lazy {
+        configManager.getString(keyDefaultYear)?.toIntOrNull() ?: Year.now().value
+    }
 
     /**
      * Supported seasons
@@ -79,12 +86,6 @@ class HomeRepository @Inject constructor(
         set(value) = preferenceManager.save(keySeenSeasons, value.map { it.toString() }.toSet())
 
     /**
-     * Is the searching of the statistics functionality enabled server side
-     */
-    val searchEnabled: Boolean
-        get() = configManager.getBoolean(keySearch)
-
-    /**
      * Show empty week indicators
      */
     var emptyWeeksInSchedule: Boolean
@@ -102,11 +103,11 @@ class HomeRepository @Inject constructor(
     /**
      * Remembering a season change
      */
-    var rememberSeasonChange: Boolean
+    var keepUserSelectedSeason: Boolean
         get() = preferenceManager.getBoolean(keyRememberSeasonChange, false)
         set(value) = preferenceManager.save(keyRememberSeasonChange, value)
 
-    var userSeasonChange: Int?
+    var userSelectedSeason: Int?
         get() = preferenceManager.getInt(keyUserSeasonChange, -1).takeIf { it != -1 }
         set(value) = preferenceManager.save(keyUserSeasonChange, value ?: -1)
 

--- a/feature/season/src/main/java/tmg/flashback/season/usecases/DefaultSeasonUseCase.kt
+++ b/feature/season/src/main/java/tmg/flashback/season/usecases/DefaultSeasonUseCase.kt
@@ -11,18 +11,31 @@ class DefaultSeasonUseCase @Inject constructor(
     val defaultSeason: Int
         get() {
             val supportedSeasons = homeRepository.supportedSeasons
-            val serverSeason = homeRepository.serverDefaultYear
-
+            // No season list available, so default to current yeah
             if (supportedSeasons.isEmpty()) {
                 return Formula1.currentSeasonYear
             }
-            return if (!supportedSeasons.contains(serverSeason)) {
-                supportedSeasons.maxOrNull()!!
+
+
+            val serverSeason = serverDefaultSeason
+            if (homeRepository.rememberSeasonChange) {
+                val usersLastSeasonSelection = homeRepository.userSeasonChange ?: serverSeason
+                if (supportedSeasons.contains(usersLastSeasonSelection)) {
+                    return usersLastSeasonSelection
+                } else {
+                    // Users last viewed season has been removed
+                    //  from supported seasons list. Reset the pref
+                    homeRepository.userSeasonChange = null
+                }
+            }
+
+            return if (!supportedSeasons.contains(serverDefaultSeason)) {
+                supportedSeasons.max()
             } else {
                 serverSeason
             }
         }
 
-    val serverDefaultSeason: Int
+    private val serverDefaultSeason: Int
         get() = homeRepository.serverDefaultYear
 }

--- a/feature/season/src/main/java/tmg/flashback/season/usecases/DefaultSeasonUseCase.kt
+++ b/feature/season/src/main/java/tmg/flashback/season/usecases/DefaultSeasonUseCase.kt
@@ -18,14 +18,14 @@ class DefaultSeasonUseCase @Inject constructor(
 
 
             val serverSeason = serverDefaultSeason
-            if (homeRepository.rememberSeasonChange) {
-                val usersLastSeasonSelection = homeRepository.userSeasonChange ?: serverSeason
+            if (homeRepository.keepUserSelectedSeason) {
+                val usersLastSeasonSelection = homeRepository.userSelectedSeason ?: serverSeason
                 if (supportedSeasons.contains(usersLastSeasonSelection)) {
                     return usersLastSeasonSelection
                 } else {
                     // Users last viewed season has been removed
                     //  from supported seasons list. Reset the pref
-                    homeRepository.userSeasonChange = null
+                    homeRepository.userSelectedSeason = null
                 }
             }
 
@@ -37,5 +37,5 @@ class DefaultSeasonUseCase @Inject constructor(
         }
 
     private val serverDefaultSeason: Int
-        get() = homeRepository.serverDefaultYear
+        get() = homeRepository.defaultSeason
 }

--- a/feature/season/src/test/java/tmg/flashback/season/presentation/dashboard/shared/seasonpicker/CurrentSeasonHolderTest.kt
+++ b/feature/season/src/test/java/tmg/flashback/season/presentation/dashboard/shared/seasonpicker/CurrentSeasonHolderTest.kt
@@ -3,6 +3,7 @@ package tmg.flashback.season.presentation.dashboard.shared.seasonpicker
 import app.cash.turbine.test
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -97,6 +98,9 @@ internal class CurrentSeasonHolderTest: BaseTest() {
 
         assertEquals(2022, underTest.currentSeason)
         assertEquals(listOf(2022, 2021), underTest.supportedSeasons)
+        verify {
+            mockHomeRepository.userSeasonChange = 2022
+        }
     }
 
     @Test
@@ -110,5 +114,8 @@ internal class CurrentSeasonHolderTest: BaseTest() {
 
         assertEquals(2020, underTest.currentSeason) // Set to 2019 via. internal logic of DefaultSeasonUseCase!!
         assertEquals(listOf(2022, 2021), underTest.supportedSeasons)
+        verify {
+            mockHomeRepository.userSeasonChange = 2019
+        }
     }
 }

--- a/feature/season/src/test/java/tmg/flashback/season/presentation/dashboard/shared/seasonpicker/CurrentSeasonHolderTest.kt
+++ b/feature/season/src/test/java/tmg/flashback/season/presentation/dashboard/shared/seasonpicker/CurrentSeasonHolderTest.kt
@@ -99,7 +99,7 @@ internal class CurrentSeasonHolderTest: BaseTest() {
         assertEquals(2022, underTest.currentSeason)
         assertEquals(listOf(2022, 2021), underTest.supportedSeasons)
         verify {
-            mockHomeRepository.userSeasonChange = 2022
+            mockHomeRepository.userSelectedSeason = 2022
         }
     }
 
@@ -115,7 +115,7 @@ internal class CurrentSeasonHolderTest: BaseTest() {
         assertEquals(2020, underTest.currentSeason) // Set to 2019 via. internal logic of DefaultSeasonUseCase!!
         assertEquals(listOf(2022, 2021), underTest.supportedSeasons)
         verify {
-            mockHomeRepository.userSeasonChange = 2019
+            mockHomeRepository.userSelectedSeason = 2019
         }
     }
 }

--- a/feature/season/src/test/java/tmg/flashback/season/repository/HomeRepositoryTest.kt
+++ b/feature/season/src/test/java/tmg/flashback/season/repository/HomeRepositoryTest.kt
@@ -4,7 +4,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import tmg.flashback.configuration.manager.ConfigManager
@@ -38,7 +37,7 @@ internal class HomeRepositoryTest {
     fun `server default year is current year if from config returns valid string`() {
         every { mockConfigManager.getString(keyDefaultYear) } returns "2020"
         initSUT()
-        assertEquals(2020, sut.serverDefaultYear)
+        assertEquals(2020, sut.defaultSeason)
         verify {
             mockConfigManager.getString(keyDefaultYear)
         }
@@ -48,7 +47,7 @@ internal class HomeRepositoryTest {
     fun `server default year is current year if from config returns non int string`() {
         every { mockConfigManager.getString(keyDefaultYear) } returns "testing"
         initSUT()
-        assertEquals(Year.now().value, sut.serverDefaultYear)
+        assertEquals(Year.now().value, sut.defaultSeason)
         verify {
             mockConfigManager.getString(keyDefaultYear)
         }
@@ -58,7 +57,7 @@ internal class HomeRepositoryTest {
     fun `server default year is current year if from config returns null`() {
         every { mockConfigManager.getString(keyDefaultYear) } returns "testing"
         initSUT()
-        assertEquals(Year.now().value, sut.serverDefaultYear)
+        assertEquals(Year.now().value, sut.defaultSeason)
         verify {
             mockConfigManager.getString(keyDefaultYear)
         }
@@ -68,12 +67,12 @@ internal class HomeRepositoryTest {
     fun `server default year is lazy loaded`() {
         every { mockConfigManager.getString(keyDefaultYear) } returns "2020"
         initSUT()
-        assertEquals(2020, sut.serverDefaultYear)
+        assertEquals(2020, sut.defaultSeason)
         verify(exactly = 1) {
             mockConfigManager.getString(keyDefaultYear)
         }
         every { mockConfigManager.getString(keyDefaultYear) } returns "2021"
-        assertEquals(2020, sut.serverDefaultYear)
+        assertEquals(2020, sut.defaultSeason)
         verify(exactly = 1) {
             mockConfigManager.getString(keyDefaultYear)
         }
@@ -234,7 +233,7 @@ internal class HomeRepositoryTest {
         every { mockPreferenceManager.getBoolean(keyRememberSeasonChange, false) } returns true
         initSUT()
 
-        assertTrue(sut.rememberSeasonChange)
+        assertTrue(sut.keepUserSelectedSeason)
         verify {
             mockPreferenceManager.getBoolean(keyRememberSeasonChange, false)
         }
@@ -244,7 +243,7 @@ internal class HomeRepositoryTest {
     fun `remember season change saves value to shared prefs repository`() {
         initSUT()
 
-        sut.rememberSeasonChange = true
+        sut.keepUserSelectedSeason = true
         verify {
             mockPreferenceManager.save(keyRememberSeasonChange, true)
         }
@@ -256,7 +255,7 @@ internal class HomeRepositoryTest {
         every { mockPreferenceManager.getInt(keyUserSeasonChange, -1) } returns -1
         initSUT()
 
-        assertEquals(null, sut.userSeasonChange)
+        assertEquals(null, sut.userSelectedSeason)
         verify {
             mockPreferenceManager.getInt(keyUserSeasonChange, -1)
         }
@@ -266,7 +265,7 @@ internal class HomeRepositoryTest {
         every { mockPreferenceManager.getInt(keyUserSeasonChange, -1) } returns 2023
         initSUT()
 
-        assertEquals(2023, sut.userSeasonChange)
+        assertEquals(2023, sut.userSelectedSeason)
         verify {
             mockPreferenceManager.getInt(keyUserSeasonChange, -1)
         }
@@ -276,7 +275,7 @@ internal class HomeRepositoryTest {
     fun `user season change setting value to null saves -1`() {
         initSUT()
 
-        sut.userSeasonChange = null
+        sut.userSelectedSeason = null
         verify {
             mockPreferenceManager.save(keyUserSeasonChange, -1)
         }
@@ -286,7 +285,7 @@ internal class HomeRepositoryTest {
     fun `user season change saves value to shared prefs repository`() {
         initSUT()
 
-        sut.userSeasonChange = 2024
+        sut.userSelectedSeason = 2024
         verify {
             mockPreferenceManager.save(keyUserSeasonChange, 2024)
         }

--- a/feature/season/src/test/java/tmg/flashback/season/repository/HomeRepositoryTest.kt
+++ b/feature/season/src/test/java/tmg/flashback/season/repository/HomeRepositoryTest.kt
@@ -230,6 +230,27 @@ internal class HomeRepositoryTest {
     }
 
     @Test
+    fun `remember season change reads value from preferences repository`() {
+        every { mockPreferenceManager.getBoolean(keyRememberSeasonChange, false) } returns true
+        initSUT()
+
+        assertTrue(sut.rememberSeasonChange)
+        verify {
+            mockPreferenceManager.getBoolean(keyRememberSeasonChange, false)
+        }
+    }
+
+    @Test
+    fun `remember season change saves value to shared prefs repository`() {
+        initSUT()
+
+        sut.rememberSeasonChange = true
+        verify {
+            mockPreferenceManager.save(keyRememberSeasonChange, true)
+        }
+    }
+
+    @Test
     fun `seasons seen reads value from preferences repository`() {
         every { mockPreferenceManager.getSet(keySeenSeasons, any()) } returns mutableSetOf("1234")
         initSUT()
@@ -317,5 +338,6 @@ internal class HomeRepositoryTest {
         private const val keyDashboardCollapseList: String = "DASHBOARD_COLLAPSE_LIST"
         private const val keyProvidedByAtTop: String = "PROVIDED_BY_AT_TOP"
         private const val keySeasonOnboarding: String = "ONBOARDING_SEASON"
+        private const val keyRememberSeasonChange: String = "REMEMBER_SEASON_CHANGE"
     }
 }

--- a/feature/season/src/test/java/tmg/flashback/season/repository/HomeRepositoryTest.kt
+++ b/feature/season/src/test/java/tmg/flashback/season/repository/HomeRepositoryTest.kt
@@ -250,6 +250,48 @@ internal class HomeRepositoryTest {
         }
     }
 
+
+    @Test
+    fun `user season change reads value from preferences repository null when not set`() {
+        every { mockPreferenceManager.getInt(keyUserSeasonChange, -1) } returns -1
+        initSUT()
+
+        assertEquals(null, sut.userSeasonChange)
+        verify {
+            mockPreferenceManager.getInt(keyUserSeasonChange, -1)
+        }
+    }
+    @Test
+    fun `user season change reads value from preferences repository value when valid`() {
+        every { mockPreferenceManager.getInt(keyUserSeasonChange, -1) } returns 2023
+        initSUT()
+
+        assertEquals(2023, sut.userSeasonChange)
+        verify {
+            mockPreferenceManager.getInt(keyUserSeasonChange, -1)
+        }
+    }
+
+    @Test
+    fun `user season change setting value to null saves -1`() {
+        initSUT()
+
+        sut.userSeasonChange = null
+        verify {
+            mockPreferenceManager.save(keyUserSeasonChange, -1)
+        }
+    }
+
+    @Test
+    fun `user season change saves value to shared prefs repository`() {
+        initSUT()
+
+        sut.userSeasonChange = 2024
+        verify {
+            mockPreferenceManager.save(keyUserSeasonChange, 2024)
+        }
+    }
+
     @Test
     fun `seasons seen reads value from preferences repository`() {
         every { mockPreferenceManager.getSet(keySeenSeasons, any()) } returns mutableSetOf("1234")
@@ -339,5 +381,6 @@ internal class HomeRepositoryTest {
         private const val keyProvidedByAtTop: String = "PROVIDED_BY_AT_TOP"
         private const val keySeasonOnboarding: String = "ONBOARDING_SEASON"
         private const val keyRememberSeasonChange: String = "REMEMBER_SEASON_CHANGE"
+        private const val keyUserSeasonChange: String = "USER_SEASON_CHANGE"
     }
 }

--- a/feature/season/src/test/java/tmg/flashback/season/usecases/DefaultSeasonUseCaseTest.kt
+++ b/feature/season/src/test/java/tmg/flashback/season/usecases/DefaultSeasonUseCaseTest.kt
@@ -20,8 +20,6 @@ internal class DefaultSeasonUseCaseTest {
         underTest = DefaultSeasonUseCase(mockHomeRepository)
     }
 
-    //region Default year
-
     @Test
     fun `returns current year if supported season list is empty`() {
         every { mockHomeRepository.supportedSeasons } returns emptySet()
@@ -32,58 +30,45 @@ internal class DefaultSeasonUseCaseTest {
     }
 
     @Test
-    fun `returns user defined value if its supported`() {
-        every { mockHomeRepository.supportedSeasons } returns setOf(2017, 2018)
-        every { mockHomeRepository.serverDefaultYear } returns 2018
+    fun `returns users last selected season if pref is enabled and season is supported`() {
+        every { mockHomeRepository.supportedSeasons } returns setOf(2016, 2017, 2018)
+        every { mockHomeRepository.userSeasonChange } returns 2017
+        every { mockHomeRepository.serverDefaultYear } returns 2016
+        every { mockHomeRepository.rememberSeasonChange } returns true
+
         initUnderTest()
 
-        assertEquals(2018, underTest.defaultSeason)
+        assertEquals(2017, underTest.defaultSeason)
     }
 
     @Test
-    fun `runs clear default method if user defined value found to be invalid`() {
-        every { mockHomeRepository.supportedSeasons } returns setOf(2019)
-        every { mockHomeRepository.serverDefaultYear } returns 2018
-        initUnderTest()
+    fun `returns server season if season if users last selected season pref is disabled`() {
+        every { mockHomeRepository.supportedSeasons } returns setOf(2016, 2017, 2018)
+        every { mockHomeRepository.userSeasonChange } returns 2017
+        every { mockHomeRepository.serverDefaultYear } returns 2016
+        every { mockHomeRepository.rememberSeasonChange } returns false
 
-        assertEquals(2019, underTest.defaultSeason)
+        initUnderTest()
+        assertEquals(2016, underTest.defaultSeason)
     }
 
     @Test
-    fun `if user defined value invalid, return server value if in supported seasons`() {
-        every { mockHomeRepository.supportedSeasons } returns setOf(2018,2019)
-        every { mockHomeRepository.serverDefaultYear } returns 2018
-        initUnderTest()
-
-        assertEquals(2018, underTest.defaultSeason)
-    }
-
-    @Test
-    fun `if user defined value is null, return server value if in supported seasons`() {
-        every { mockHomeRepository.supportedSeasons } returns setOf(2018,2019)
-        every { mockHomeRepository.serverDefaultYear } returns 2018
-        initUnderTest()
-
-        assertEquals(2018, underTest.defaultSeason)
-    }
-
-    @Test
-    fun `if user defined value invalid or null, return max in supported seasons value if server value is not valid`() {
-        every { mockHomeRepository.supportedSeasons } returns setOf(2018,2019)
+    fun `returns server season if season is supported`() {
+        every { mockHomeRepository.supportedSeasons } returns setOf(2016, 2017, 2018)
         every { mockHomeRepository.serverDefaultYear } returns 2017
-        initUnderTest()
+        every { mockHomeRepository.rememberSeasonChange } returns false
 
-        assertEquals(2019, underTest.defaultSeason)
+        initUnderTest()
+        assertEquals(2017, underTest.defaultSeason)
     }
 
     @Test
-    fun `default season server returns the server configured default season`() {
-        every { mockHomeRepository.serverDefaultYear } returns 2018
+    fun `returns latest supported season if server season doesnt exist`() {
+        every { mockHomeRepository.supportedSeasons } returns setOf(2016, 2017, 2018)
+        every { mockHomeRepository.serverDefaultYear } returns 2020
+        every { mockHomeRepository.rememberSeasonChange } returns false
+
         initUnderTest()
-        assertEquals(2018, underTest.serverDefaultSeason)
-        verify {
-            mockHomeRepository.serverDefaultYear
-        }
+        assertEquals(2018, underTest.defaultSeason)
     }
-    //endregion
 }

--- a/feature/season/src/test/java/tmg/flashback/season/usecases/DefaultSeasonUseCaseTest.kt
+++ b/feature/season/src/test/java/tmg/flashback/season/usecases/DefaultSeasonUseCaseTest.kt
@@ -2,10 +2,7 @@ package tmg.flashback.season.usecases
 
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import tmg.flashback.formula1.constants.Formula1
 import tmg.flashback.season.repository.HomeRepository
@@ -23,7 +20,7 @@ internal class DefaultSeasonUseCaseTest {
     @Test
     fun `returns current year if supported season list is empty`() {
         every { mockHomeRepository.supportedSeasons } returns emptySet()
-        every { mockHomeRepository.serverDefaultYear } returns 2018
+        every { mockHomeRepository.defaultSeason } returns 2018
         initUnderTest()
 
         assertEquals(Formula1.currentSeasonYear, underTest.defaultSeason)
@@ -32,9 +29,9 @@ internal class DefaultSeasonUseCaseTest {
     @Test
     fun `returns users last selected season if pref is enabled and season is supported`() {
         every { mockHomeRepository.supportedSeasons } returns setOf(2016, 2017, 2018)
-        every { mockHomeRepository.userSeasonChange } returns 2017
-        every { mockHomeRepository.serverDefaultYear } returns 2016
-        every { mockHomeRepository.rememberSeasonChange } returns true
+        every { mockHomeRepository.userSelectedSeason } returns 2017
+        every { mockHomeRepository.defaultSeason } returns 2016
+        every { mockHomeRepository.keepUserSelectedSeason } returns true
 
         initUnderTest()
 
@@ -44,9 +41,9 @@ internal class DefaultSeasonUseCaseTest {
     @Test
     fun `returns server season if season if users last selected season pref is disabled`() {
         every { mockHomeRepository.supportedSeasons } returns setOf(2016, 2017, 2018)
-        every { mockHomeRepository.userSeasonChange } returns 2017
-        every { mockHomeRepository.serverDefaultYear } returns 2016
-        every { mockHomeRepository.rememberSeasonChange } returns false
+        every { mockHomeRepository.userSelectedSeason } returns 2017
+        every { mockHomeRepository.defaultSeason } returns 2016
+        every { mockHomeRepository.keepUserSelectedSeason } returns false
 
         initUnderTest()
         assertEquals(2016, underTest.defaultSeason)
@@ -55,8 +52,8 @@ internal class DefaultSeasonUseCaseTest {
     @Test
     fun `returns server season if season is supported`() {
         every { mockHomeRepository.supportedSeasons } returns setOf(2016, 2017, 2018)
-        every { mockHomeRepository.serverDefaultYear } returns 2017
-        every { mockHomeRepository.rememberSeasonChange } returns false
+        every { mockHomeRepository.defaultSeason } returns 2017
+        every { mockHomeRepository.keepUserSelectedSeason } returns false
 
         initUnderTest()
         assertEquals(2017, underTest.defaultSeason)
@@ -65,8 +62,8 @@ internal class DefaultSeasonUseCaseTest {
     @Test
     fun `returns latest supported season if server season doesnt exist`() {
         every { mockHomeRepository.supportedSeasons } returns setOf(2016, 2017, 2018)
-        every { mockHomeRepository.serverDefaultYear } returns 2020
-        every { mockHomeRepository.rememberSeasonChange } returns false
+        every { mockHomeRepository.defaultSeason } returns 2020
+        every { mockHomeRepository.keepUserSelectedSeason } returns false
 
         initUnderTest()
         assertEquals(2018, underTest.defaultSeason)

--- a/presentation/strings/src/main/res/values-es/strings.xml
+++ b/presentation/strings/src/main/res/values-es/strings.xml
@@ -252,6 +252,8 @@
     <string name="settings_pref_empty_week_description">Mostrar un pequeño indicador de espaciado entre carreras para resaltar las dobles y triples cabeceras en la próxima temporada</string>
     <string name="settings_pref_recent_highlights_title">Destacados recientes</string>
     <string name="settings_pref_recent_highlights_description">Mostrar el banner de destacados recientes en la página de inicio si estás conectado a Internet. Esto suele contener enlaces a historias importantes de la última semana aproximadamente</string>
+    <string name="settings_pref_remember_season_change_title">Recordar cambio de temporada</string>
+    <string name="settings_pref_remember_season_change_description">Recordar la última temporada vista entre reinicios de la aplicación</string>
     <string name="settings_section_rss_configure_title">Configurar</string>
     <string name="settings_section_rss_configure_description">Configurar fuentes RSS o personalizar la apariencia</string>
     <string name="settings_section_web_browser_title">Navegador en la aplicación</string>

--- a/presentation/strings/src/main/res/values-it/strings.xml
+++ b/presentation/strings/src/main/res/values-it/strings.xml
@@ -252,6 +252,8 @@
     <string name="settings_pref_empty_week_description">Mostra un piccolo indicatore di spaziatura tra le gare per evidenziare i doppi e i tripli header nella stagione imminente</string>
     <string name="settings_pref_recent_highlights_title">Momenti salienti recenti</string>
     <string name="settings_pref_recent_highlights_description">Mostra il banner dei momenti salienti recenti nella home page se connesso a internet. Di solito contiene collegamenti a storie significative dell\'ultima settimana circa</string>
+    <string name="settings_pref_remember_season_change_title">Ricorda il cambio di stagione</string>
+    <string name="settings_pref_remember_season_change_description">Ricorda l\'ultima stagione visualizzata tra un riavvio e l\'altro dell\'app</string>
     <string name="settings_section_rss_configure_title">Configura</string>
     <string name="settings_section_rss_configure_description">Configura le fonti RSS o personalizza l\'aspetto</string>
     <string name="settings_section_web_browser_title">Browser in-app</string>

--- a/presentation/strings/src/main/res/values-zh/strings.xml
+++ b/presentation/strings/src/main/res/values-zh/strings.xml
@@ -249,6 +249,8 @@
     <string name="settings_pref_empty_week_description">在比赛之间显示一个小间距指示器，以突出即将到来的赛季中的双重和三重比赛</string>
     <string name="settings_pref_recent_highlights_title">近期亮点</string>
     <string name="settings_pref_recent_highlights_description">如果已连接到互联网，则在主页上显示近期亮点横幅。这通常包含过去一周左右的重要商店的链接</string>
+    <string name="settings_pref_remember_season_change_title">记住季节变化</string>
+    <string name="settings_pref_remember_season_change_description">记住应用重启期间观看的最后一个季节</string>
     <string name="settings_section_rss_configure_title">配置</string>
     <string name="settings_section_rss_configure_description">设置 RSS 源或自定义外观</string>
     <string name="settings_section_web_browser_title">应用内浏览器</string>

--- a/presentation/strings/src/main/res/values/strings.xml
+++ b/presentation/strings/src/main/res/values/strings.xml
@@ -278,8 +278,8 @@
     <string name="settings_pref_empty_week_description">Show a little spacing indicator between races to highlight double and triple headers in the upcoming season</string>
     <string name="settings_pref_recent_highlights_title">Recent highlights</string>
     <string name="settings_pref_recent_highlights_description">Show the recent highlights banner on the home page if connected to the internet. This usually contains links to significant stores within the past week or so</string>
-    <string name="settings_pref_remember_season_change_title">Remember season change</string>
-    <string name="settings_pref_remember_season_change_description">Remember the last season viewed between app restarts</string>
+    <string name="settings_pref_remember_season_change_title">Keep last season</string>
+    <string name="settings_pref_remember_season_change_description">Resume from the season that was last being viewed</string>
 
     <string name="settings_section_rss_configure_title">Configure</string>
     <string name="settings_section_rss_configure_description">Setup RSS sources or customise appearance</string>
@@ -437,7 +437,7 @@
     <string name="settings_web_browser_javascript_description">Enable javascript in the in-app browser. This can help webpages load quicker, but may affect page functionality</string>
 
     <string name="settings_restart_app_required">Your change will take effect when the app restarts</string>
-    <string name="settings_experimental">Experimental</string>
+    <string name="settings_experimental">BETA</string>
     <string name="settings_experimental_description">This feature is in beta, and as such may not be working correctly.</string>
 
     <string name="settings_rss_title">RSS</string>

--- a/presentation/strings/src/main/res/values/strings.xml
+++ b/presentation/strings/src/main/res/values/strings.xml
@@ -278,6 +278,8 @@
     <string name="settings_pref_empty_week_description">Show a little spacing indicator between races to highlight double and triple headers in the upcoming season</string>
     <string name="settings_pref_recent_highlights_title">Recent highlights</string>
     <string name="settings_pref_recent_highlights_description">Show the recent highlights banner on the home page if connected to the internet. This usually contains links to significant stores within the past week or so</string>
+    <string name="settings_pref_remember_season_change_title">Remember season change</string>
+    <string name="settings_pref_remember_season_change_description">Remember the last season viewed between app restarts</string>
 
     <string name="settings_section_rss_configure_title">Configure</string>
     <string name="settings_section_rss_configure_description">Setup RSS sources or customise appearance</string>


### PR DESCRIPTION
Add the option to keep the last selected season when navigating around
- When enabled, the app will open on the last viewed season
- When disabled, the app will open on the current season